### PR TITLE
Add context menu support with a toggle switch in options

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -27,12 +27,24 @@ browser.storage.onChanged.addListener((changes) => {
   }
 });
 
-// 工具栏按钮功能保持不变
-browser.action.onClicked.addListener(async () => {
-  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-  const url = tabs[0].url;
-  const decodedUrl = decodeURIComponent(url);
-  await navigator.clipboard.writeText(decodedUrl);
+// 工具栏按钮功能：直接利用传进来的 tab 对象
+browser.action.onClicked.addListener(async (tab) => {
+  // 调试信息：如果这里还打印 undefined，说明 manifest 权限没生效
+  console.log("Current tab URL:", tab.url);
+
+  if (tab.url) {
+    try {
+      const decodedUrl = decodeURIComponent(tab.url);
+      await navigator.clipboard.writeText(decodedUrl);
+      
+      // 可选：添加一个简单的通知，确认复制成功
+      console.log("URL copied!");
+    } catch (e) {
+      console.error("Failed to copy/decode URL:", e);
+    }
+  } else {
+    console.error("No URL found. Check 'activeTab' permission.");
+  }
 });
 
 // 监听右键点击

--- a/src/background.js
+++ b/src/background.js
@@ -1,9 +1,48 @@
-browser.action.onClicked.addListener((tab) => {
-    // decodeURI(window.location.href);
-    const duri = decodeURI(tab.url);
-    navigator.clipboard.writeText(duri).then(() => {
-        console.log(`${duri}`)
-    }).catch(err => {
-        console.error(err);
-    })
+const MENU_ID = "copy-decoded-link";
+
+// 初始化右键菜单
+async function setupContextMenu() {
+  const result = await browser.storage.local.get({ showContextMenu: true });
+  
+  // 先尝试移除，防止重复创建报错
+  await browser.contextMenus.removeAll();
+
+  if (result.showContextMenu) {
+    browser.contextMenus.create({
+      id: MENU_ID,
+      title: "Copy Decoded URL",
+      contexts: ["link"]
+    });
+  }
+}
+
+// 监听安装或启动
+browser.runtime.onInstalled.addListener(setupContextMenu);
+browser.runtime.onStartup.addListener(setupContextMenu);
+
+// 监听配置变化
+browser.storage.onChanged.addListener((changes) => {
+  if (changes.showContextMenu) {
+    setupContextMenu();
+  }
+});
+
+// 工具栏按钮功能保持不变
+browser.action.onClicked.addListener(async () => {
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  const url = tabs[0].url;
+  const decodedUrl = decodeURIComponent(url);
+  await navigator.clipboard.writeText(decodedUrl);
+});
+
+// 监听右键点击
+browser.contextMenus.onClicked.addListener((info) => {
+  if (info.menuItemId === MENU_ID) {
+    try {
+      const decodedUrl = decodeURIComponent(info.linkUrl);
+      navigator.clipboard.writeText(decodedUrl);
+    } catch (e) {
+      console.error("Failed to decode URL:", e);
+    }
+  }
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,32 +1,37 @@
 {
-    "manifest_version": 3,
-    "name": "Copy Decoded URL",
-    "version": "0.2.2",
-    "author": "hms5232",
-    "description": "Quickly copy the decoded URL with a click.",
-    "homepage_url": "https://github.com/hms5232/firefox-copy-decoded-url",
-    "icons": {
-        "48": "icons/btn-48.png",
-        "96": "icons/btn-96.png"
-    },
-    "browser_specific_settings": {
-        "gecko": {
-            "id": "{0f693142-6faf-4ba6-b423-1542da3ee2d1}",
-            "strict_min_version": "109.0",
-            "data_collection_permissions": {
-                "required": ["none"]
-            }
-        }
-    },
-    "permissions": [
-        "activeTab",
-        "clipboardWrite"
-    ],
-    "action": {
-        "default_icon": "icons/btn-96.png",
-        "default_title": "Copy Decoded URL"
-    },
-    "background": {
-        "scripts": ["background.js"]
+  "manifest_version": 3,
+  "name": "Copy Decoded URL",
+  "version": "0.2.3",
+  "author": "hms5232",
+  "description": "Quickly copy the decoded URL with a click.",
+  "homepage_url": "https://github.com/hms5232/firefox-copy-decoded-url",
+  "icons": {
+    "48": "icons/btn-48.png",
+    "96": "icons/btn-96.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{0f693142-6faf-4ba6-b423-1542da3ee2d1}",
+      "strict_min_version": "109.0",
+      "data_collection_permissions": {
+          "collects_data": false,
+          "required": ["none"]
+      }
     }
+  },
+  "permissions": [
+    "contextMenus",
+    "storage"
+  ],
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": false
+  },
+  "action": {
+    "default_icon": "icons/btn-96.png",
+    "default_title": "Copy decoded URL"
+  },
+  "background": {
+    "scripts": ["background.js"]
+  }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,9 +19,11 @@
       }
     }
   },
-  "permissions": [
+ "permissions": [
     "contextMenus",
-    "storage"
+    "storage",
+    "activeTab",
+    "clipboardWrite"
   ],
   "options_ui": {
     "page": "options.html",

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Settings</title>
+    <style>
+        body { padding: 10px; font-family: sans-serif; }
+        .option { margin-bottom: 10px; }
+    </style>
+</head>
+<body>
+    <div class="option">
+        <label>
+            <input type="checkbox" id="showContextMenu"> Display "Copy Decoded URL" in the right-click context menu
+        </label>
+    </div>
+    <script src="options.js"></script>
+</body>
+</html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,13 @@
+const checkbox = document.querySelector("#showContextMenu");
+
+// 加载初始值
+browser.storage.local.get({ showContextMenu: true }).then((result) => {
+  checkbox.checked = result.showContextMenu;
+});
+
+// 保存改动
+checkbox.addEventListener("change", (e) => {
+  browser.storage.local.set({
+    showContextMenu: e.target.checked
+  });
+});


### PR DESCRIPTION
Hello! I've enhanced this extension with a few new features:

1. Context Menu: Added "Copy Decoded Link" when right-clicking on a link.
2. Options Page: Added a toggle switch in the extension options to enable/disable the context menu, keeping the context menu clean for those who don't need it.

Tested on Firefox with Manifest V3. Hope you find this useful!

**Title and description above generated from Google Gemini .
Most code written by Google Gemini and Claude Haiku .
I tested it and it works.**